### PR TITLE
Add express server for todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ Launches the test runner in the interactive watch mode.
 
 Builds the app for production to the `build` folder.
 
+## Server
+
+The `server` folder contains a small Node.js API that persists the todo list in
+`lowdb`. To start it:
+
+```bash
+cd server
+npm install
+npm start
+```
+
+By default the API will be available on `http://localhost:4000`.
+

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,21 @@
+# Todo Server
+
+This folder contains a simple Node.js server using Express and Lowdb to store todo list data.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the server:
+
+```bash
+npm start
+```
+
+The server listens on port `4000` by default.
+
+The database is stored in the `db.json` file inside this folder and will be created automatically on first run.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const cors = require('cors');
+const { Low } = require('lowdb');
+const { JSONFile } = require('lowdb/node');
+
+const app = express();
+const port = process.env.PORT || 4000;
+
+const adapter = new JSONFile('db.json');
+const db = new Low(adapter);
+
+async function init() {
+  await db.read();
+  db.data ||= { tasks: [], nextId: 1 };
+  await db.write();
+}
+
+init();
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/tasks', async (req, res) => {
+  await db.read();
+  res.json(db.data.tasks);
+});
+
+app.post('/tasks', async (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ error: 'text is required' });
+  await db.read();
+  const task = { id: db.data.nextId++, text, completed: false };
+  db.data.tasks.push(task);
+  await db.write();
+  res.status(201).json(task);
+});
+
+app.put('/tasks/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  await db.read();
+  const task = db.data.tasks.find(t => t.id === id);
+  if (!task) return res.sendStatus(404);
+  Object.assign(task, req.body);
+  await db.write();
+  res.json(task);
+});
+
+app.delete('/tasks/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  await db.read();
+  const index = db.data.tasks.findIndex(t => t.id === id);
+  if (index === -1) return res.sendStatus(404);
+  db.data.tasks.splice(index, 1);
+  await db.write();
+  res.sendStatus(204);
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "lowdb": "^6.0.1"
+  }
+}

--- a/src/features/todoSlice.ts
+++ b/src/features/todoSlice.ts
@@ -14,19 +14,15 @@ const initialState: TodoState = {
   tasks: [],
 };
 
-let nextId = 1;
-
 const todoSlice = createSlice({
   name: 'todo',
   initialState,
   reducers: {
-    addTask: {
-      reducer: (state, action: PayloadAction<Task>) => {
-        state.tasks.push(action.payload);
-      },
-      prepare: (text: string) => ({
-        payload: { id: nextId++, text, completed: false } as Task,
-      }),
+    setTasks: (state, action: PayloadAction<Task[]>) => {
+      state.tasks = action.payload;
+    },
+    addTask: (state, action: PayloadAction<Task>) => {
+      state.tasks.push(action.payload);
     },
     removeTask: (state, action: PayloadAction<number>) => {
       state.tasks = state.tasks.filter(task => task.id !== action.payload);
@@ -43,5 +39,5 @@ const todoSlice = createSlice({
   },
 });
 
-export const { addTask, removeTask, updateTask } = todoSlice.actions;
+export const { setTasks, addTask, removeTask, updateTask } = todoSlice.actions;
 export default todoSlice.reducer;

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,25 +1,55 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../hooks';
-import { addTask, removeTask, updateTask } from '../features/todoSlice';
+import { addTask, removeTask, updateTask, setTasks } from '../features/todoSlice';
+
+const API_URL = 'http://localhost:4000';
 
 const TodoPage: React.FC = () => {
   const tasks = useAppSelector(state => state.todo.tasks);
   const dispatch = useAppDispatch();
   const [text, setText] = useState('');
 
-  const handleAdd = () => {
+  useEffect(() => {
+    fetch(`${API_URL}/tasks`)
+      .then(res => res.json())
+      .then(data => dispatch(setTasks(data)))
+      .catch(console.error);
+  }, [dispatch]);
+
+  const handleAdd = async () => {
     if (text.trim()) {
-      dispatch(addTask(text.trim()));
+      const res = await fetch(`${API_URL}/tasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text.trim() }),
+      });
+      const newTask = await res.json();
+      dispatch(addTask(newTask));
       setText('');
     }
   };
 
-  const handleToggle = (id: number, completed: boolean) => {
+  const handleToggle = async (id: number, completed: boolean) => {
+    await fetch(`${API_URL}/tasks/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completed: !completed }),
+    });
     dispatch(updateTask({ id, completed: !completed }));
   };
 
-  const handleChange = (id: number, newText: string) => {
+  const handleChange = async (id: number, newText: string) => {
+    await fetch(`${API_URL}/tasks/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: newText }),
+    });
     dispatch(updateTask({ id, text: newText }));
+  };
+
+  const handleRemove = async (id: number) => {
+    await fetch(`${API_URL}/tasks/${id}`, { method: 'DELETE' });
+    dispatch(removeTask(id));
   };
 
   return (
@@ -43,7 +73,7 @@ const TodoPage: React.FC = () => {
               value={task.text}
               onChange={e => handleChange(task.id, e.target.value)}
             />
-            <button onClick={() => dispatch(removeTask(task.id))}>Remove</button>
+            <button onClick={() => handleRemove(task.id)}>Remove</button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add a small Node.js express server with lowdb in `server`
- document how to start the server
- persist todos via REST API and integrate client with fetch
- update redux slice to handle server-provided tasks

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*