### PR TITLE
Fix lowdb init and ignore server node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Ignore server dependencies
+server/node_modules

--- a/server/index.js
+++ b/server/index.js
@@ -7,11 +7,12 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 const adapter = new JSONFile('db.json');
-const db = new Low(adapter);
+const defaultData = { tasks: [], nextId: 1 };
+const db = new Low(adapter, defaultData);
 
 async function init() {
   await db.read();
-  db.data ||= { tasks: [], nextId: 1 };
+  db.data ||= defaultData;
   await db.write();
 }
 


### PR DESCRIPTION
## Summary
- pass default data to lowdb
- reference default data during initialization
- ignore server/node_modules folder

## Testing
- `npm test` *(fails: react-scripts not found)*