### PR TITLE
Add JWT auth with login/register pages

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,12 +2,18 @@ import express from 'express';
 import cors from 'cors';
 import { Low } from 'lowdb';
 import { JSONFile } from 'lowdb/node';
+import crypto from 'crypto';
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 const adapter = new JSONFile('db.json');
-const defaultData = { tasks: [], nextId: 1 };
+const defaultData = {
+  tasks: [],
+  nextId: 1,
+  users: [],
+  nextUserId: 1,
+};
 const db = new Low(adapter, defaultData);
 
 async function init() {
@@ -18,38 +24,132 @@ async function init() {
 
 await init();
 
+const secret = process.env.JWT_SECRET || 'secret';
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64url');
+}
+
+function signToken(payload) {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+function verifyToken(token) {
+  const [header, body, signature] = token.split('.');
+  if (!header || !body || !signature) return null;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+  if (signature !== expected) return null;
+  try {
+    return JSON.parse(Buffer.from(body, 'base64url').toString());
+  } catch {
+    return null;
+  }
+}
+
+function hashPassword(password, salt = crypto.randomBytes(16).toString('hex')) {
+  const hash = crypto
+    .pbkdf2Sync(password, salt, 1000, 64, 'sha512')
+    .toString('hex');
+  return { salt, hash };
+}
+
+function verifyPassword(password, salt, hash) {
+  const hashed = crypto
+    .pbkdf2Sync(password, salt, 1000, 64, 'sha512')
+    .toString('hex');
+  return hashed === hash;
+}
+
 app.use(cors());
 app.use(express.json());
 
-app.get('/tasks', async (req, res) => {
+function authMiddleware(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) return res.sendStatus(401);
+  const payload = verifyToken(auth.slice(7));
+  if (!payload) return res.sendStatus(401);
+  req.user = payload;
+  next();
+}
+
+app.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
   await db.read();
-  res.json(db.data.tasks);
+  if (db.data.users.find(u => u.username === username)) {
+    return res.status(400).json({ error: 'user exists' });
+  }
+  const { salt, hash } = hashPassword(password);
+  const user = { id: db.data.nextUserId++, username, salt, hash };
+  db.data.users.push(user);
+  await db.write();
+  const token = signToken({ id: user.id, username: user.username });
+  res.status(201).json({ token });
 });
 
-app.post('/tasks', async (req, res) => {
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  await db.read();
+  const user = db.data.users.find(u => u.username === username);
+  if (!user || !verifyPassword(password, user.salt, user.hash)) {
+    return res.status(400).json({ error: 'invalid credentials' });
+  }
+  const token = signToken({ id: user.id, username: user.username });
+  res.json({ token });
+});
+
+app.get('/me', authMiddleware, async (req, res) => {
+  res.json({ id: req.user.id, username: req.user.username });
+});
+
+app.get('/tasks', authMiddleware, async (req, res) => {
+  await db.read();
+  const tasks = db.data.tasks.filter(t => t.userId === req.user.id);
+  res.json(tasks);
+});
+
+app.post('/tasks', authMiddleware, async (req, res) => {
   const { text } = req.body;
   if (!text) return res.status(400).json({ error: 'text is required' });
   await db.read();
-  const task = { id: db.data.nextId++, text, completed: false };
+  const task = {
+    id: db.data.nextId++,
+    text,
+    completed: false,
+    userId: req.user.id,
+  };
   db.data.tasks.push(task);
   await db.write();
   res.status(201).json(task);
 });
 
-app.put('/tasks/:id', async (req, res) => {
+app.put('/tasks/:id', authMiddleware, async (req, res) => {
   const id = parseInt(req.params.id, 10);
   await db.read();
-  const task = db.data.tasks.find(t => t.id === id);
+  const task = db.data.tasks.find(t => t.id === id && t.userId === req.user.id);
   if (!task) return res.sendStatus(404);
   Object.assign(task, req.body);
   await db.write();
   res.json(task);
 });
 
-app.delete('/tasks/:id', async (req, res) => {
+app.delete('/tasks/:id', authMiddleware, async (req, res) => {
   const id = parseInt(req.params.id, 10);
   await db.read();
-  const index = db.data.tasks.findIndex(t => t.id === id);
+  const index = db.data.tasks.findIndex(
+    t => t.id === id && t.userId === req.user.id
+  );
   if (index === -1) return res.sendStatus(404);
   db.data.tasks.splice(index, 1);
   await db.write();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Header from './components/Header';
 import TodoPage from './pages/TodoPage';
 import PageTwo from './pages/PageTwo';
 import PageThree from './pages/PageThree';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
 
 const App: React.FC = () => (
   <>
@@ -12,6 +14,8 @@ const App: React.FC = () => (
       <Route path="/" element={<TodoPage />} />
       <Route path="/two" element={<PageTwo />} />
       <Route path="/three" element={<PageThree />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
     </Routes>
   </>
 );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,8 @@ import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '@mui/material/Button';
 import { useThemeContext } from '../ThemeContext';
+import { useAppDispatch, useAppSelector } from '../hooks';
+import { logout } from '../features/authSlice';
 
 const Nav = styled.nav`
   background: ${({ theme }) => theme.palette.background.paper};
@@ -20,6 +22,8 @@ const tabSx = {
 
 const Header: React.FC = () => {
   const { toggleTheme, mode } = useThemeContext();
+  const dispatch = useAppDispatch();
+  const auth = useAppSelector(state => state.auth);
   return (
     <Nav>
     <Button
@@ -53,6 +57,23 @@ const Header: React.FC = () => {
     >
       Page Three
     </Button>
+    {auth.token ? (
+      <>
+        <span style={{ margin: '0 0.5rem' }}>Hello, {auth.username}</span>
+        <Button onClick={() => dispatch(logout())} sx={tabSx}>
+          Logout
+        </Button>
+      </>
+    ) : (
+      <>
+        <Button component={NavLink} to="/login" sx={tabSx}>
+          Login
+        </Button>
+        <Button component={NavLink} to="/register" sx={tabSx}>
+          Register
+        </Button>
+      </>
+    )
       <Button onClick={toggleTheme} sx={tabSx}>
         {mode === 'light' ? 'Dark' : 'Light'} Mode
       </Button>

--- a/src/features/authSlice.ts
+++ b/src/features/authSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  token: string | null;
+  username: string | null;
+}
+
+const initialState: AuthState = {
+  token: localStorage.getItem('token'),
+  username: localStorage.getItem('username'),
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setCredentials: (
+      state,
+      action: PayloadAction<{ token: string; username: string }>
+    ) => {
+      state.token = action.payload.token;
+      state.username = action.payload.username;
+      localStorage.setItem('token', action.payload.token);
+      localStorage.setItem('username', action.payload.username);
+    },
+    logout: state => {
+      state.token = null;
+      state.username = null;
+      localStorage.removeItem('token');
+      localStorage.removeItem('username');
+    },
+  },
+});
+
+export const { setCredentials, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
+import { useAppDispatch } from '../hooks';
+import { setCredentials } from '../features/authSlice';
+import { useNavigate, Link } from 'react-router-dom';
+
+const API_URL = 'http://localhost:4000';
+
+const LoginPage: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = async () => {
+    const res = await fetch(`${API_URL}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      dispatch(setCredentials({ token: data.token, username }));
+      navigate('/');
+    } else {
+      alert('Login failed');
+    }
+  };
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h2>Login</h2>
+      <TextField
+        label="Username"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+        sx={{ m: 1 }}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        sx={{ m: 1 }}
+      />
+      <Button variant="contained" onClick={handleSubmit} sx={{ m: 1 }}>
+        Login
+      </Button>
+      <div>
+        <Link to="/register">Register</Link>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { TextField, Button } from '@mui/material';
+import { setCredentials } from '../features/authSlice';
+import { useAppDispatch } from '../hooks';
+import { useNavigate, Link } from 'react-router-dom';
+
+const API_URL = 'http://localhost:4000';
+
+const RegisterPage: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = async () => {
+    const res = await fetch(`${API_URL}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      dispatch(setCredentials({ token: data.token, username }));
+      navigate('/');
+    } else {
+      alert('Registration failed');
+    }
+  };
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h2>Register</h2>
+      <TextField
+        label="Username"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+        sx={{ m: 1 }}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        sx={{ m: 1 }}
+      />
+      <Button variant="contained" onClick={handleSubmit} sx={{ m: 1 }}>
+        Register
+      </Button>
+      <div>
+        <Link to="/login">Login</Link>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import todoReducer from './features/todoSlice';
+import authReducer from './features/authSlice';
 
 // Example slice showing the typical setup
 const exampleSlice = createSlice({
@@ -18,6 +19,7 @@ export const store = configureStore({
   reducer: {
     example: exampleSlice.reducer,
     todo: todoReducer,
+    auth: authReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- add JWT-based authentication middleware on the server
- secure tasks per user and expose register/login endpoints
- add auth slice to Redux store
- create Login and Register pages
- add login/logout buttons to header and secure Todo page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*