### PR TITLE
Add default admin user

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -19,3 +19,12 @@ npm start
 The server listens on port `4000` by default.
 
 The database is stored in the `db.json` file inside this folder and will be created automatically on first run.
+
+## Default Credentials
+
+On first start the database is populated with a default user:
+
+- **Username:** `admin`
+- **Password:** `admin`
+
+You can use these credentials to log in without registering a new account.

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,12 @@ const db = new Low(adapter, defaultData);
 async function init() {
   await db.read();
   db.data ||= defaultData;
+  // ensure default admin user exists
+  if (!db.data.users.find(u => u.username === 'admin')) {
+    const { salt, hash } = hashPassword('admin');
+    const user = { id: db.data.nextUserId++, username: 'admin', salt, hash };
+    db.data.users.push(user);
+  }
   await db.write();
 }
 


### PR DESCRIPTION
## Summary
- seed the server with a default `admin` user
- document the credentials in the server README

## Testing
- `npm test` *(fails: react-scripts not found)*