### PR TITLE
Implement per-user todo lists

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,8 @@
 # Todo Server
 
-This folder contains a simple Node.js server using Express and Lowdb to store todo list data.
+This folder contains a simple Node.js server using Express and Lowdb to store
+user accounts and todo list data. Each user keeps their own tasks in the
+database.
 
 ## Setup
 
@@ -19,6 +21,8 @@ npm start
 The server listens on port `4000` by default.
 
 The database is stored in the `db.json` file inside this folder and will be created automatically on first run.
+Tasks are stored inside each user object, so every user has their own `tasks`
+array and `nextTaskId` counter.
 
 ## Default Credentials
 
@@ -28,3 +32,9 @@ On first start the database is populated with a default user:
 - **Password:** `admin`
 
 You can use these credentials to log in without registering a new account.
+
+Both the register and login endpoints respond with:
+
+```json
+{ "token": "...", "userId": 1, "username": "admin" }
+```

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,13 @@
+{
+  "users": [
+    {
+      "id": 1,
+      "username": "admin",
+      "salt": "67c84fe466d9ab27a4467a8fa56f9a3c",
+      "hash": "1f17c542dc2c71966f9da1a074987725a7668511e3e0cd74439f167e9046431b69e1618820ee630d9fdf62dfb1b4ae41599afb4364c50993addcaab6fda1df3d",
+      "tasks": [],
+      "nextTaskId": 1
+    }
+  ],
+  "nextUserId": 2
+}

--- a/src/features/authSlice.ts
+++ b/src/features/authSlice.ts
@@ -3,11 +3,15 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 interface AuthState {
   token: string | null;
   username: string | null;
+  userId: number | null;
 }
 
 const initialState: AuthState = {
   token: localStorage.getItem('token'),
   username: localStorage.getItem('username'),
+  userId: localStorage.getItem('userId')
+    ? Number(localStorage.getItem('userId'))
+    : null,
 };
 
 const authSlice = createSlice({
@@ -16,18 +20,22 @@ const authSlice = createSlice({
   reducers: {
     setCredentials: (
       state,
-      action: PayloadAction<{ token: string; username: string }>
+      action: PayloadAction<{ token: string; username: string; userId: number }>
     ) => {
       state.token = action.payload.token;
       state.username = action.payload.username;
+      state.userId = action.payload.userId;
       localStorage.setItem('token', action.payload.token);
       localStorage.setItem('username', action.payload.username);
+      localStorage.setItem('userId', String(action.payload.userId));
     },
     logout: state => {
       state.token = null;
       state.username = null;
+      state.userId = null;
       localStorage.removeItem('token');
       localStorage.removeItem('username');
+      localStorage.removeItem('userId');
     },
   },
 });

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -20,7 +20,13 @@ const LoginPage: React.FC = () => {
     });
     if (res.ok) {
       const data = await res.json();
-      dispatch(setCredentials({ token: data.token, username }));
+      dispatch(
+        setCredentials({
+          token: data.token,
+          username: data.username,
+          userId: data.userId,
+        })
+      );
       navigate('/');
     } else {
       alert('Login failed');

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -20,7 +20,13 @@ const RegisterPage: React.FC = () => {
     });
     if (res.ok) {
       const data = await res.json();
-      dispatch(setCredentials({ token: data.token, username }));
+      dispatch(
+        setCredentials({
+          token: data.token,
+          username: data.username,
+          userId: data.userId,
+        })
+      );
       navigate('/');
     } else {
       alert('Registration failed');


### PR DESCRIPTION
## Summary
- adapt DB layout to store tasks inside user objects
- update server routes for new structure and return userId on login/register
- keep an example `db.json` with a default admin user
- persist userId in auth slice
- update login and register pages to store userId
- document new server behaviour

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684807d505e483249308f68fa0fa98ea