### PR TITLE
Protect pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,14 +6,36 @@ import Time from './pages/Time';
 import TickTackGame from './pages/TickTackGame';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const App: React.FC = () => (
   <>
     <Header />
     <Routes>
-      <Route path="/" element={<TodoPage />} />
-      <Route path="/time" element={<Time />} />
-      <Route path="/ticktackgame" element={<TickTackGame />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <TodoPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/time"
+        element={
+          <ProtectedRoute>
+            <Time />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/ticktackgame"
+        element={
+          <ProtectedRoute>
+            <TickTackGame />
+          </ProtectedRoute>
+        }
+      />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
     </Routes>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAppSelector } from '../hooks';
+
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const token = useAppSelector(state => state.auth.token);
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## Summary
- add ProtectedRoute component that redirects to `/login`
- wrap todo list, time, and ticktack game pages in ProtectedRoute

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848194485c08324a448c2d3e6358e77